### PR TITLE
Enforce JSX attribute value

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ These rules are purely matters of style and are quite subjective.
 * [jsx-conditional-newline](docs/rules/jsx-conditional-newline.md): Require a newline when a conditional expression is used within JSX.
 * [jsx-conditional-parens](docs/rules/jsx-conditional-parens.md): Require no parens when JSX is used within a conditional.
 * [jsx-curly-spacing-opinionated](docs/rules/jsx-curly-spacing-opinionated): Require particular spacing rules that cannot be defined using jsx-curly-spacing inside eslint-plugin-react.
+* [jsx-enforce-prop-usage](docs/rules/jsx-enforce-prop-usage): Enforce how props are used. Can help to enforce extracting inline function calls to variables.
 
 # Contributing
 Contributions are always welcome!.

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ These rules are purely matters of style and are quite subjective.
 * [jsx-conditional-indent](docs/rules/jsx-conditional-indent.md): Require a indented line when a conditional expression spans multiple lines inside JSX.
 * [jsx-conditional-newline](docs/rules/jsx-conditional-newline.md): Require a newline when a conditional expression is used within JSX.
 * [jsx-conditional-parens](docs/rules/jsx-conditional-parens.md): Require no parens when JSX is used within a conditional.
-* [jsx-curly-spacing-opinionated](docs/rules/jsx-curly-spacing-opinionated): Require particular spacing rules that cannot be defined using jsx-curly-spacing inside eslint-plugin-react.
-* [jsx-enforce-prop-usage](docs/rules/jsx-enforce-prop-usage): Enforce how props are used. Can help to enforce extracting inline function calls to variables.
+* [jsx-curly-spacing-opinionated](docs/rules/jsx-curly-spacing-opinionated.md): Require particular spacing rules that cannot be defined using jsx-curly-spacing inside eslint-plugin-react.
+* [jsx-enforce-prop-usage](docs/rules/jsx-enforce-prop-usage.md): Enforce how props are used. Can help to enforce extracting inline function calls to variables.
 
 # Contributing
 Contributions are always welcome!.

--- a/docs/rules/jsx-enforce-prop-usage.md
+++ b/docs/rules/jsx-enforce-prop-usage.md
@@ -12,11 +12,11 @@ The following patterns are considered problems:
 ```js
 /*eslint saxo/jsx-enforce-prop-usage: "error"*/
 
-<div className={classNames('abc', {a: true})} />
-<div className={true ? 'a' : 'v'} />
+<div className={classNames('abc', {a: true})} /> // inline call not allowed, need to extract to variable
+<div className={true ? 'a' : 'v'} /> // not allowed, need to extract to variable
 
 let foo = 'a b c';
-<div className={foo}/>
+<div className={foo}/> // variable name not allowed, must be `classes`, `className` or contain `Classes`, `ClassName` or `CLASS`
 ```
 
 The following patterns are not considered warnings:
@@ -24,24 +24,24 @@ The following patterns are not considered warnings:
 ```js
 /*eslint saxo/jsx-enforce-prop-usage: "error"*/
 
-<div className="inline-classes defined-with-string"/>
+<div className="inline-classes defined-with-string"/> // string value allowed
+
+<div className={`allow template literals`}/> // template literals allowed
 
 const classes = classNames('abc', {a: true});
-<div className={classes}/>
+<div className={classes}/> // allowed variable name ("classes")
 
 let fooClasses = 'a b c';
-<div className={fooClasses}/>
+<div className={fooClasses}/> // allowed variable name (ends with "Classes")
 
 const className = 'a b c';
-<div className={className}/>
+<div className={className}/> // allowed variable name ("className")
 
 let fooClassName = 'a b c';
-<div className={fooClassName}/>
+<div className={fooClassName}/> // allowed variable name (ends with "ClassName")
 
 const option = { className: 'a' };
-<div className={option.className}/>
+<div className={option.className}/> // can use object's key which name matches allowed set of names (must be `classes`, `className` or contain `Classes`, `ClassName` or `CLASS`)
 
-<div className={\`allow template literals\`}/>
-
-<div className={constants.DIV_CLASS}/>
+<div className={constants.DIV_CLASS}/> // contains CLASS
 ```

--- a/docs/rules/jsx-enforce-prop-usage.md
+++ b/docs/rules/jsx-enforce-prop-usage.md
@@ -1,0 +1,25 @@
+# jsx-enforce-prop-usage
+
+The eslint prop usage rule enforces className JSX attribute values to be one of:
+* string literal
+* template literal
+* variable with specific name: `classes`, `className` or containing `Classes`, `ClassName` or `CLASS`
+
+## Rule Details
+
+The following patterns are considered problems:
+
+```js
+/*eslint saxo/jsx-enforce-prop-usage: "error"*/
+
+<Sheet className={classNames('grid grid--y grid--fit-fill-fit', className)}>
+```
+
+The following patterns are not considered warnings:
+
+```js
+/*eslint saxo/jsx-enforce-prop-usage: "error"*/
+
+const classes = classNames('grid grid--y grid--fit-fill-fit', this.props.className);
+<Sheet className={classes}/>
+```

--- a/docs/rules/jsx-enforce-prop-usage.md
+++ b/docs/rules/jsx-enforce-prop-usage.md
@@ -12,7 +12,11 @@ The following patterns are considered problems:
 ```js
 /*eslint saxo/jsx-enforce-prop-usage: "error"*/
 
-<Sheet className={classNames('grid grid--y grid--fit-fill-fit', className)}>
+<div className={classNames('abc', {a: true})} />
+<div className={true ? 'a' : 'v'} />
+
+let foo = 'a b c';
+<div className={foo}/>
 ```
 
 The following patterns are not considered warnings:
@@ -20,6 +24,24 @@ The following patterns are not considered warnings:
 ```js
 /*eslint saxo/jsx-enforce-prop-usage: "error"*/
 
-const classes = classNames('grid grid--y grid--fit-fill-fit', this.props.className);
-<Sheet className={classes}/>
+<div className="inline-classes defined-with-string"/>
+
+const classes = classNames('abc', {a: true});
+<div className={classes}/>
+
+let fooClasses = 'a b c';
+<div className={fooClasses}/>
+
+const className = 'a b c';
+<div className={className}/>
+
+let fooClassName = 'a b c';
+<div className={fooClassName}/>
+
+const option = { className: 'a' };
+<div className={option.className}/>
+
+<div className={\`allow template literals\`}/>
+
+<div className={constants.DIV_CLASS}/>
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ module.exports = {
                 '@saxo/saxo/jsx-conditional-newline': 'error',
                 '@saxo/saxo/jsx-conditional-parens': 'error',
                 '@saxo/saxo/jsx-curly-spacing-opinionated': 'error',
+                '@saxo/saxo/jsx-enforce-prop-usage': 'warn',
             },
         },
     },

--- a/src/rules/jsx-enforce-prop-usage.js
+++ b/src/rules/jsx-enforce-prop-usage.js
@@ -10,7 +10,8 @@ const isAllowedName = (name = '') => (
     name === 'classes' ||
     name === 'className' ||
     name.indexOf('Classes') > -1 ||
-    name.indexOf('ClassName') > -1
+    name.indexOf('ClassName') > -1 ||
+    name.indexOf('CLASS') > -1
 );
 
 module.exports = {

--- a/src/rules/jsx-enforce-prop-usage.js
+++ b/src/rules/jsx-enforce-prop-usage.js
@@ -33,16 +33,16 @@ module.exports = {
                 if (node.value.type === 'JSXExpressionContainer') {
                     if (node.value.expression.type === 'Identifier') {
                         // TODO: refactor
-                        if (node.value.expression.name === 'classes') {
+                        if (node.value.expression.name === 'classes' || node.value.expression.name === 'className') {
                             return;
                         }
-                        if (node.value.expression.name.indexOf('Classes') > -1) {
+                        if (node.value.expression.name.indexOf('Classes') > -1 || node.value.expression.name.indexOf('ClassName') > -1) {
                             return;
                         }
                     }
                 }
 
-                context.report(node, `${attributeNameToCheck} attribute value must be string or variable with classes name or ending with Classes`);
+                context.report(node, 'className attribute value must be string or variable which name ends with "classes" or "className"');
             },
         };
     },

--- a/src/rules/jsx-enforce-prop-usage.js
+++ b/src/rules/jsx-enforce-prop-usage.js
@@ -6,6 +6,13 @@ const attributeNameToCheck = 'className';
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+const isAllowedName = (name = '') => (
+    name === 'classes' ||
+    name === 'className' ||
+    name.indexOf('Classes') > -1 ||
+    name.indexOf('ClassName') > -1
+);
+
 module.exports = {
     meta: {
         docs: {
@@ -32,13 +39,17 @@ module.exports = {
 
                 if (node.value.type === 'JSXExpressionContainer') {
                     if (node.value.expression.type === 'Identifier') {
-                        // TODO: refactor
-                        if (node.value.expression.name === 'classes' || node.value.expression.name === 'className') {
+                        if (isAllowedName(node.value.expression.name)) {
+                            // allow variables with appropriate
                             return;
                         }
-                        if (node.value.expression.name.indexOf('Classes') > -1 || node.value.expression.name.indexOf('ClassName') > -1) {
-                            return;
-                        }
+                    }
+                }
+
+                if (node.value.expression.type === 'MemberExpression' && node.value.expression.property.type === 'Identifier') {
+                    if (isAllowedName(node.value.expression.property.name)) {
+                        // allow objects keys with appropriate name
+                        return;
                     }
                 }
 

--- a/src/rules/jsx-enforce-prop-usage.js
+++ b/src/rules/jsx-enforce-prop-usage.js
@@ -33,7 +33,7 @@ module.exports = {
                 }
 
                 if (node.value.type === 'Literal') {
-                    // allow string literals as attributes
+                    // allow any string literals as attributes
                     return;
                 }
 
@@ -43,6 +43,10 @@ module.exports = {
                             // allow variables with appropriate
                             return;
                         }
+                    }
+                    if (node.value.expression.type === 'TemplateLiteral') {
+                        // allow any template literals
+                        return;
                     }
                 }
 

--- a/src/rules/jsx-enforce-prop-usage.js
+++ b/src/rules/jsx-enforce-prop-usage.js
@@ -49,12 +49,11 @@ module.exports = {
                         // allow any template literals
                         return;
                     }
-                }
-
-                if (node.value.expression.type === 'MemberExpression' && node.value.expression.property.type === 'Identifier') {
-                    if (isAllowedName(node.value.expression.property.name)) {
-                        // allow objects keys with appropriate name
-                        return;
+                    if (node.value.expression.type === 'MemberExpression' && node.value.expression.property.type === 'Identifier') {
+                        if (isAllowedName(node.value.expression.property.name)) {
+                            // allow objects keys with appropriate name
+                            return;
+                        }
                     }
                 }
 

--- a/src/rules/jsx-enforce-prop-usage.js
+++ b/src/rules/jsx-enforce-prop-usage.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const attributeNameToCheck = 'className';
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: 'Enforce prop value',
+            category: '',
+            recommended: false,
+        },
+        schema: [],
+    },
+
+    create(context) {
+
+        return {
+            JSXAttribute(node) {
+                if (!node.value || node.name.name !== attributeNameToCheck) {
+                    // only check attributes with given name
+                    return;
+                }
+
+                if (node.value.type === 'Literal') {
+                    // allow string literals as attributes
+                    return;
+                }
+
+                if (node.value.type === 'JSXExpressionContainer') {
+                    if (node.value.expression.type === 'Identifier') {
+                        // TODO: refactor
+                        if (node.value.expression.name === 'classes') {
+                            return;
+                        }
+                        if (node.value.expression.name.indexOf('Classes') > -1) {
+                            return;
+                        }
+                    }
+                }
+
+                context.report(node, `${attributeNameToCheck} attribute value must be string or variable with classes name or ending with Classes`);
+            },
+        };
+    },
+};

--- a/tests/lib/rules/jsx-enforce-prop-usage.js
+++ b/tests/lib/rules/jsx-enforce-prop-usage.js
@@ -59,6 +59,13 @@ const option = { className: 'a' };
 />
 `,
         },
+        {
+            code: `
+<SettingOption
+    className={\`allow template literals\`}
+/>
+`,
+        },
     ],
     invalid: [
         {

--- a/tests/lib/rules/jsx-enforce-prop-usage.js
+++ b/tests/lib/rules/jsx-enforce-prop-usage.js
@@ -51,6 +51,14 @@ let fooClassName = 'a b c';
 <div className={fooClassName}/>;
 `,
         },
+        {
+            code: `
+const option = { className: 'a' };
+<SettingOption
+    className={option.className}
+/>
+`,
+        },
     ],
     invalid: [
         {

--- a/tests/lib/rules/jsx-enforce-prop-usage.js
+++ b/tests/lib/rules/jsx-enforce-prop-usage.js
@@ -1,0 +1,56 @@
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const { RuleTester } = require('eslint');
+const rule = require('../../../src/rules/jsx-enforce-prop-usage');
+const parserOptions = {
+    sourceType: 'module',
+    ecmaVersion: 6,
+    ecmaFeatures: {
+        jsx: true,
+    },
+};
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({ parserOptions });
+ruleTester.run('jsx-conditional-indent', rule, {
+    valid: [
+        {
+            code: `
+<div className="inline-classes defined-with-string"/>;
+`,
+        },
+        {
+            code: `
+const classes = 'a b c';
+<div className={classes}/>;
+`,
+        },
+        {
+            code: `
+let fooClasses = 'a b c';
+<div className={fooClasses}/>;
+`,
+        },
+    ],
+    invalid: [
+        {
+            code: `
+<div className={classNames('abc', {a: true})} />;
+`,
+            errors: [{ message: 'className attribute value must be string or variable with classes name or ending with Classes' }],
+        },
+        {
+            code: `
+<div className={true ? 'a' : 'v'} />;;
+`,
+            errors: [{ message: 'className attribute value must be string or variable with classes name or ending with Classes' }],
+        },
+    ],
+});

--- a/tests/lib/rules/jsx-enforce-prop-usage.js
+++ b/tests/lib/rules/jsx-enforce-prop-usage.js
@@ -66,6 +66,13 @@ const option = { className: 'a' };
 />
 `,
         },
+        {
+            code: `
+<SettingOption
+    className={constants.SPLITTER_HANDLE_CLASS}
+/>
+`,
+        },
     ],
     invalid: [
         {

--- a/tests/lib/rules/jsx-enforce-prop-usage.js
+++ b/tests/lib/rules/jsx-enforce-prop-usage.js
@@ -13,6 +13,7 @@ const parserOptions = {
         jsx: true,
     },
 };
+const expectedErrorMessage = 'className attribute value must be string or variable which name ends with "classes" or "className"';
 
 // ------------------------------------------------------------------------------
 // Tests
@@ -38,19 +39,38 @@ let fooClasses = 'a b c';
 <div className={fooClasses}/>;
 `,
         },
+        {
+            code: `
+const className = 'a b c';
+<div className={className}/>;
+`,
+        },
+        {
+            code: `
+let fooClassName = 'a b c';
+<div className={fooClassName}/>;
+`,
+        },
     ],
     invalid: [
         {
             code: `
 <div className={classNames('abc', {a: true})} />;
 `,
-            errors: [{ message: 'className attribute value must be string or variable with classes name or ending with Classes' }],
+            errors: [{ message: expectedErrorMessage }],
         },
         {
             code: `
-<div className={true ? 'a' : 'v'} />;;
+<div className={true ? 'a' : 'v'} />;
 `,
-            errors: [{ message: 'className attribute value must be string or variable with classes name or ending with Classes' }],
+            errors: [{ message: expectedErrorMessage }],
+        },
+        {
+            code: `
+let foo = 'a b c';
+<div className={foo}/>;
+`,
+            errors: [{ message: expectedErrorMessage }],
         },
     ],
 });


### PR DESCRIPTION
New rule to help enforcing not using inline `classNames` calls in JSX `className` attribute:

```
// don`t
<Sheet className={classNames('grid grid--y grid--fit-fill-fit', className)}>
  
// use
const classes = classNames('grid grid--y grid--fit-fill-fit', this.props.className);
<Sheet className={classes}/>
```

The rule only checks JSX attributes named `className` and allows string, template literals and variables with the name containing `classes`, `className` or `CLASS`.
In future rule may be enhanced to allow configuration (custom attribute name, allow / disallow literals, configure variable names that are allowed).

Related to: http://tfs:8080/tfs/DefaultCollection/TP%20Git/_git/SaxoTrader/pullrequest/20463