### PR TITLE
Add new rule to enforce spec describe arg matching path of tested file

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ These rules are purely matters of style and are quite subjective.
 * [jsx-conditional-parens](docs/rules/jsx-conditional-parens.md): Require no parens when JSX is used within a conditional.
 * [jsx-curly-spacing-opinionated](docs/rules/jsx-curly-spacing-opinionated.md): Require particular spacing rules that cannot be defined using jsx-curly-spacing inside eslint-plugin-react.
 * [jsx-enforce-prop-usage](docs/rules/jsx-enforce-prop-usage.md): Enforce how props are used. Can help to enforce extracting inline function calls to variables.
+* [jsx-enforce-spec-describe](docs/rules/jsx-enforce-spec-describe.md): Enforces *.spec.* unit tests top level describe method to have first argument matching path of file under test.
 
 # Contributing
 Contributions are always welcome!.

--- a/docs/rules/jsx-enforce-spec-describe.md
+++ b/docs/rules/jsx-enforce-spec-describe.md
@@ -1,0 +1,93 @@
+# jsx-enforce-spec-describe
+
+The eslint spec describe rule enforces *.spec.* unit tests top level describe method to have first argument matching path of file under test.
+
+The rule accepts _topLevelDir_ option which allows to suggest expected fix. Example:
+
+```json
+"saxo/jsx-enforce-spec-describe": [
+    "error",
+    {
+        "topLevelDir": "Project/Source/FrontendApp/js/"
+    }
+],
+```
+
+For `Project/Source/FrontendApp/js/` the spec file located in `C:\Projects\Source\FrontendApp\js\src\modules\foo\foo.spec.jsx'` the first argument of `describe` method will be enforced to be `'src/modules/foo/foo'`.
+
+This also works for unix paths, example: `/home/dev/Project/Source/FrontendApp/js/src/modules/foo/foo.spec.jsx'` -> `'src/modules/foo/foo'`.
+
+The rule is autofixable.
+
+## Rule Details
+
+The following patterns are considered problems:
+
+```js
+/*
+"saxo/jsx-enforce-spec-describe": [
+    "error",
+    {
+        "topLevelDir": "SampleProject/Source/SampleProject.App/js/"
+    }
+],
+*/
+
+// for file location: 'C:\\Projects\\SampleProject\\Source\\SampleProject.App\\js\\src\\modules\\sampleModule\\component\\component.spec.jsx',
+describe('src/modules/incorrect/directory/and/file', () => {
+    it('should throw error for unit test description not matching path', () => {})
+})
+// This will be autofixed to:
+describe('src/modules/sampleModule/component/component', () => {
+    it('should throw error for unit test description not matching path', () => {})
+})
+
+// for file location: '/some/dir/SampleProject/Source/SampleProject.App/js/src/modules/sampleModule/component/component.spec.jsx',
+describe('src/modules/incorrect/directory/and/file', () => {
+    it('should throw error for unit test description not matching path', () => {})
+})
+// This will be autofixed to:
+describe('src/modules/sampleModule/component/component', () => {
+    it('should throw error for unit test description not matching path', () => {})
+})
+```
+
+The following patterns are not considered warnings:
+
+```js
+/*
+"saxo/jsx-enforce-spec-describe": [
+    "error",
+    {
+        "topLevelDir": "SampleProject/Source/SampleProject.App/js/"
+    }
+],
+*/
+
+// for file location: 'C:\\Projects\\SampleProject\\Source\\SampleProject.App\\js\\src\\modules\\sampleModule\\component\\component.jsx'
+describe(() => {
+    it('should be valid for non spec file with windows path', () => {})
+})
+
+// for file location: 'C:\\Projects\\SampleProject\\Source\\SampleProject.App\\js\\src\\modules\\sampleModule\\component\\component.spec.jsx',
+describe('src/modules/sampleModule/component/component', () => {
+    it('should be valid for spec file with expected windows path in the description', () => {})
+})
+
+// for file location: '/some/dir/SampleProject/Source/SampleProject.App/js/src/modules/sampleModule/component/component.jsx',
+describe(() => {
+    it('should be valid for non spec file with unix path', () => {})
+})
+
+// for file location: '/some/dir/SampleProject/Source/SampleProject.App/js/src/modules/sampleModule/component/component.spec.jsx',
+describe('src/modules/sampleModule/component/component', () => {
+    it('should be valid for spec file with expected unix path in the description', () => {})
+})
+
+// for file location: 'C:\\Projects\\SampleProject\\Source\\SampleProject.App\\js\\src\\modules\\sampleModule\\component\\component.spec.jsx',
+describe('src/modules/sampleModule/component/component', () => {
+    describe('anything', () => {
+        it('should allow anything in the nested describe', () => {})
+    })
+})
+```

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ module.exports = {
                 '@saxo/saxo/jsx-conditional-parens': 'error',
                 '@saxo/saxo/jsx-curly-spacing-opinionated': 'error',
                 '@saxo/saxo/jsx-enforce-prop-usage': 'warn',
+                '@saxo/saxo/jsx-enforce-spec-describe': 'warn',
             },
         },
     },

--- a/src/rules/jsx-enforce-spec-describe.js
+++ b/src/rules/jsx-enforce-spec-describe.js
@@ -1,0 +1,69 @@
+'use strict';
+
+// find only top level describe
+const estQuery = 'Program > ExpressionStatement > CallExpression > Identifier[name=\'describe\']';
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: 'Enforce content of describe() in spec files matching tested file path',
+            category: '',
+            recommended: false,
+        },
+        fixable: 'code',
+        schema: [
+            {
+                type: 'object',
+                properties: {
+                    topLevelDir: {
+                        type: 'string', // path of top level js directory
+                    },
+                },
+            },
+        ],
+    },
+
+    create(context) {
+        const optionsObject = context.options[0] || {};
+        const topLevelDir = optionsObject.topLevelDir || '/js/';
+
+        return {
+            [estQuery](node) {
+                const fileName = context.getFilename().replace(/\\/g, '/');
+
+                if (fileName.indexOf('.spec.') === -1) {
+                    // only check spec files
+                    return;
+                }
+
+                const expectedDescription = fileName
+                    .substring(topLevelDir.length + fileName.indexOf(topLevelDir)) // leave only src/... part
+                    .replace(/\.spec\.[^/.]+$/, ''); // remove extension
+
+                const actualDescription = node.parent.arguments[0].value;
+
+                if (actualDescription === expectedDescription) {
+                    return;
+                }
+
+                const errorMessage = 'First argument of describe() needs to be path to tested file, ' +
+                    `expected=[${expectedDescription}], got=[${actualDescription}]`;
+
+                context.report({
+                    node,
+                    loc: node.loc.start,
+                    message: errorMessage,
+                    fix(fixer) {
+                        const firstDescribeArgumentNode = node.parent.arguments[0];
+                        const correctPath = `'${expectedDescription}'`;
+                        return fixer.replaceText(firstDescribeArgumentNode, correctPath);
+                    },
+                });
+            },
+        };
+    },
+};

--- a/tests/lib/rules/jsx-enforce-spec-describe.js
+++ b/tests/lib/rules/jsx-enforce-spec-describe.js
@@ -13,7 +13,7 @@ const parserOptions = {
         jsx: true,
     },
 };
-const topLevelDir = 'SaxoTrader/Source/Iit.SaxoTrader.App/js/';
+const topLevelDir = 'SampleProject/Source/SampleProject.App/js/';
 
 // ------------------------------------------------------------------------------
 // Tests
@@ -23,7 +23,7 @@ const ruleTester = new RuleTester({ parserOptions });
 ruleTester.run('jsx-conditional-indent', rule, {
     valid: [
         {
-            filename: 'C:\\Projects\\SaxoTrader\\Source\\Iit.SaxoTrader.App\\js\\src\\modules\\initialWorkspaceChoice\\session\\session.jsx',
+            filename: 'C:\\Projects\\SampleProject\\Source\\SampleProject.App\\js\\src\\modules\\sampleModule\\component\\component.jsx',
             options: [{ topLevelDir }],
             code: `
 describe(() => {
@@ -32,15 +32,15 @@ describe(() => {
 `,
         },
         {
-            filename: 'C:\\Projects\\SaxoTrader\\Source\\Iit.SaxoTrader.App\\js\\src\\modules\\initialWorkspaceChoice\\session\\session.spec.jsx',
+            filename: 'C:\\Projects\\SampleProject\\Source\\SampleProject.App\\js\\src\\modules\\sampleModule\\component\\component.spec.jsx',
             code: `
-describe('src/modules/initialWorkspaceChoice/session/session', () => {
+describe('src/modules/sampleModule/component/component', () => {
     it('should be valid for spec file with expected windows path in the description', () => {})
 })
 `,
         },
         {
-            filename: '/some/dir/SaxoTrader/Source/Iit.SaxoTrader.App/js/src/modules/initialWorkspaceChoice/session/session.jsx',
+            filename: '/some/dir/SampleProject/Source/SampleProject.App/js/src/modules/sampleModule/component/component.jsx',
             code: `
 describe(() => {
     it('should be valid for non spec file with unix path', () => {})
@@ -48,17 +48,17 @@ describe(() => {
 `,
         },
         {
-            filename: '/some/dir/SaxoTrader/Source/Iit.SaxoTrader.App/js/src/modules/initialWorkspaceChoice/session/session.spec.jsx',
+            filename: '/some/dir/SampleProject/Source/SampleProject.App/js/src/modules/sampleModule/component/component.spec.jsx',
             code: `
-describe('src/modules/initialWorkspaceChoice/session/session', () => {
+describe('src/modules/sampleModule/component/component', () => {
     it('should be valid for spec file with expected unix path in the description', () => {})
 })
 `,
         },
         {
-            filename: 'C:\\Projects\\SaxoTrader\\Source\\Iit.SaxoTrader.App\\js\\src\\modules\\initialWorkspaceChoice\\session\\session.spec.jsx',
+            filename: 'C:\\Projects\\SampleProject\\Source\\SampleProject.App\\js\\src\\modules\\sampleModule\\component\\component.spec.jsx',
             code: `
-describe('src/modules/initialWorkspaceChoice/session/session', () => {
+describe('src/modules/sampleModule/component/component', () => {
     describe('anything', () => {
         it('should allow anything in the nested describe', () => {})
     })
@@ -68,41 +68,41 @@ describe('src/modules/initialWorkspaceChoice/session/session', () => {
     ],
     invalid: [
         {
-            filename: 'C:\\Projects\\SaxoTrader\\Source\\Iit.SaxoTrader.App\\js\\src\\modules\\initialWorkspaceChoice\\session\\session.spec.jsx',
+            filename: 'C:\\Projects\\SampleProject\\Source\\SampleProject.App\\js\\src\\modules\\sampleModule\\component\\component.spec.jsx',
             code: `
 describe('src/modules/incorrect/directory/and/file', () => {
     it('should throw error for unit test description not matching path', () => {})
 })
 `,
             output: `
-describe('src/modules/initialWorkspaceChoice/session/session', () => {
+describe('src/modules/sampleModule/component/component', () => {
     it('should throw error for unit test description not matching path', () => {})
 })
 `,
             errors: [
                 {
                     message: 'First argument of describe() needs to be path to tested file, ' +
-                        'expected=[src/modules/initialWorkspaceChoice/session/session], ' +
+                        'expected=[src/modules/sampleModule/component/component], ' +
                         'got=[src/modules/incorrect/directory/and/file]',
                 },
             ],
         },
         {
-            filename: '/some/dir/SaxoTrader/Source/Iit.SaxoTrader.App/js/src/modules/initialWorkspaceChoice/session/session.spec.jsx',
+            filename: '/some/dir/SampleProject/Source/SampleProject.App/js/src/modules/sampleModule/component/component.spec.jsx',
             code: `
 describe('src/modules/incorrect/directory/and/file', () => {
     it('should throw error for unit test description not matching path', () => {})
 })
 `,
             output: `
-describe('src/modules/initialWorkspaceChoice/session/session', () => {
+describe('src/modules/sampleModule/component/component', () => {
     it('should throw error for unit test description not matching path', () => {})
 })
 `,
             errors: [
                 {
                     message: 'First argument of describe() needs to be path to tested file, ' +
-                        'expected=[src/modules/initialWorkspaceChoice/session/session], ' +
+                        'expected=[src/modules/sampleModule/component/component], ' +
                         'got=[src/modules/incorrect/directory/and/file]',
                 },
             ],

--- a/tests/lib/rules/jsx-enforce-spec-describe.js
+++ b/tests/lib/rules/jsx-enforce-spec-describe.js
@@ -1,0 +1,111 @@
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const { RuleTester } = require('eslint');
+const rule = require('../../../src/rules/jsx-enforce-spec-describe');
+const parserOptions = {
+    sourceType: 'module',
+    ecmaVersion: 6,
+    ecmaFeatures: {
+        jsx: true,
+    },
+};
+const topLevelDir = 'SaxoTrader/Source/Iit.SaxoTrader.App/js/';
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({ parserOptions });
+ruleTester.run('jsx-conditional-indent', rule, {
+    valid: [
+        {
+            filename: 'C:\\Projects\\SaxoTrader\\Source\\Iit.SaxoTrader.App\\js\\src\\modules\\initialWorkspaceChoice\\session\\session.jsx',
+            options: [{ topLevelDir }],
+            code: `
+describe(() => {
+    it('should be valid for non spec file with windows path', () => {})
+})
+`,
+        },
+        {
+            filename: 'C:\\Projects\\SaxoTrader\\Source\\Iit.SaxoTrader.App\\js\\src\\modules\\initialWorkspaceChoice\\session\\session.spec.jsx',
+            code: `
+describe('src/modules/initialWorkspaceChoice/session/session', () => {
+    it('should be valid for spec file with expected windows path in the description', () => {})
+})
+`,
+        },
+        {
+            filename: '/some/dir/SaxoTrader/Source/Iit.SaxoTrader.App/js/src/modules/initialWorkspaceChoice/session/session.jsx',
+            code: `
+describe(() => {
+    it('should be valid for non spec file with unix path', () => {})
+})
+`,
+        },
+        {
+            filename: '/some/dir/SaxoTrader/Source/Iit.SaxoTrader.App/js/src/modules/initialWorkspaceChoice/session/session.spec.jsx',
+            code: `
+describe('src/modules/initialWorkspaceChoice/session/session', () => {
+    it('should be valid for spec file with expected unix path in the description', () => {})
+})
+`,
+        },
+        {
+            filename: 'C:\\Projects\\SaxoTrader\\Source\\Iit.SaxoTrader.App\\js\\src\\modules\\initialWorkspaceChoice\\session\\session.spec.jsx',
+            code: `
+describe('src/modules/initialWorkspaceChoice/session/session', () => {
+    describe('anything', () => {
+        it('should allow anything in the nested describe', () => {})
+    })
+})
+`,
+        },
+    ],
+    invalid: [
+        {
+            filename: 'C:\\Projects\\SaxoTrader\\Source\\Iit.SaxoTrader.App\\js\\src\\modules\\initialWorkspaceChoice\\session\\session.spec.jsx',
+            code: `
+describe('src/modules/incorrect/directory/and/file', () => {
+    it('should throw error for unit test description not matching path', () => {})
+})
+`,
+            output: `
+describe('src/modules/initialWorkspaceChoice/session/session', () => {
+    it('should throw error for unit test description not matching path', () => {})
+})
+`,
+            errors: [
+                {
+                    message: 'First argument of describe() needs to be path to tested file, ' +
+                        'expected=[src/modules/initialWorkspaceChoice/session/session], ' +
+                        'got=[src/modules/incorrect/directory/and/file]',
+                },
+            ],
+        },
+        {
+            filename: '/some/dir/SaxoTrader/Source/Iit.SaxoTrader.App/js/src/modules/initialWorkspaceChoice/session/session.spec.jsx',
+            code: `
+describe('src/modules/incorrect/directory/and/file', () => {
+    it('should throw error for unit test description not matching path', () => {})
+})
+`,
+            output: `
+describe('src/modules/initialWorkspaceChoice/session/session', () => {
+    it('should throw error for unit test description not matching path', () => {})
+})
+`,
+            errors: [
+                {
+                    message: 'First argument of describe() needs to be path to tested file, ' +
+                        'expected=[src/modules/initialWorkspaceChoice/session/session], ' +
+                        'got=[src/modules/incorrect/directory/and/file]',
+                },
+            ],
+        },
+    ],
+});


### PR DESCRIPTION
The eslint spec describe rule enforces *.spec.* unit tests top level describe method to have first argument matching path of file under test.

The rule accepts _topLevelDir_ option which allows to suggest expected fix. Example:

```json
"saxo/jsx-enforce-spec-describe": [
    "error",
    {
        "topLevelDir": "Project/Source/FrontendApp/js/"
    }
],
```

For `Project/Source/FrontendApp/js/` the spec file located in `C:\Projects\Source\FrontendApp\js\src\modules\foo\foo.spec.jsx'` the first argument of `describe` method will be enforced to be `'src/modules/foo/foo'`.

This also works for unix paths, example: `/home/dev/Project/Source/FrontendApp/js/src/modules/foo/foo.spec.jsx'` -> `'src/modules/foo/foo'`.

The rule is autofixable.