### PR TITLE
Add new rule for jest clean snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ These rules are purely matters of style and are quite subjective.
 * [jsx-curly-spacing-opinionated](docs/rules/jsx-curly-spacing-opinionated.md): Require particular spacing rules that cannot be defined using jsx-curly-spacing inside eslint-plugin-react.
 * [jsx-enforce-prop-usage](docs/rules/jsx-enforce-prop-usage.md): Enforce how props are used. Can help to enforce extracting inline function calls to variables.
 * [jsx-enforce-spec-describe](docs/rules/jsx-enforce-spec-describe.md): Enforces *.spec.* unit tests top level describe method to have first argument matching path of file under test.
+* [clean-jest-snapshots](docs/rules/clean-jest-snapshots.md): Checks for code smells in jest snapshots.
 
 # Contributing
 Contributions are always welcome!.

--- a/docs/rules/clean-jest-snapshots.md
+++ b/docs/rules/clean-jest-snapshots.md
@@ -1,0 +1,156 @@
+# clean-jest-snapshots
+
+The eslint clean jest snapshots rule check for code smells in **.snap* files that contain [Jest snapshots](docs/rules/jsx-conditional-indent.md) and in **.js* files with [inline Jest snapshots](https://jestjs.io/docs/en/snapshot-testing#inline-snapshots) created using `toMatchInlineSnapshot` and `toThrowErrorMatchingInlineSnapshot` methods.
+
+The rule must be configured with mandatory _codeSmells_ option array which allows to specify patterns in snapshots that will yield errors. Example:
+
+```js
+'saxo/clean-jest-snapshots': ['error', {
+    codeSmells: [
+        {
+            codeSmellPattern: 'className=""',
+            reportedError: 'Empty value of className is not allowed, make sure to pass undefined to className attribute in jsx if you don\'t want any class names - this will prevent rendering unnecessary class attribute to DOM'
+        },
+        {
+            codeSmellPattern: 'undefinedpx',
+            reportedError: 'undefinedpx is not allowed as attribute value'
+        },
+    ],
+}],
+```
+
+For presented configuration the rule will thor error each time it encounters `className=""` and `undefinedpx` in snapshots.
+
+The rule is not autofixable.
+
+## Rule Details
+
+### The following patterns are considered problems:
+
+1) Snaphot file `foo.spec.js.snap`:
+```js
+/*
+'saxo/clean-jest-snapshots': ['error', {
+    codeSmells: [        
+        {
+            codeSmellPattern: 'undefinedpx',
+            reportedError: 'undefinedpx is not allowed as attribute value'
+        },
+    ],
+}],
+ */
+
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`src/components/foo/bar renders correctly 1`] = `
+<FooBar
+    width="undefinedpx"
+/>
+`;
+```
+
+2) Inline snapshot within unit test `foo.spec.js`:
+
+```js
+/*
+'saxo/clean-jest-snapshots': ['error', {
+    codeSmells: [        
+        {
+            codeSmellPattern: 'undefinedpx',
+            reportedError: 'undefinedpx is not allowed as attribute value'
+        },
+    ],
+}],
+ */
+
+expect(wrapper).toMatchInlineSnapshot(`
+<FooBar
+    width="undefinedpx"
+/>
+`);
+```
+
+### The following patterns are not considered errors:
+
+1) Snaphot file `foo.spec.js.snap`:
+```js
+/*
+'saxo/clean-jest-snapshots': ['error', {
+    codeSmells: [        
+        {
+            codeSmellPattern: 'undefinedpx',
+            reportedError: 'undefinedpx is not allowed as attribute value'
+        },
+    ],
+}],
+ */
+
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`src/components/foo/bar renders correctly 1`] = `
+<FooBar
+    width="100px"
+/>
+`;
+```
+
+2) Inline snapshot within unit test `foo.spec.js`:
+
+```js
+/*
+'saxo/clean-jest-snapshots': ['error', {
+    codeSmells: [        
+        {
+            codeSmellPattern: 'undefinedpx',
+            reportedError: 'undefinedpx is not allowed as attribute value'
+        },
+    ],
+}],
+ */
+
+expect(wrapper).toMatchInlineSnapshot(`
+<FooBar
+    width="100px"
+/>
+`);
+```
+
+## Configuration
+
+Example of `.eslintrc.js`:
+
+```js
+module.exports = {
+    root: true,
+    parser: 'babel-eslint',
+    parserOptions: {
+        ecmaVersion: 6,
+        ecmaFeatures: {
+            jsx: true,
+        },
+        sourceType: 'module',
+    },
+    overrides: [
+        {
+            files: ['js/src/**/*.{snap,js}'],
+            plugins: [
+                'eslint-plugin-saxo',
+            ],
+            rules: {
+                'saxo/clean-jest-snapshots': ["error", {
+                    "codeSmells": [
+                        {
+                            "codeSmellPattern": 'className=""',
+                            "reportedError": 'Empty value of className is not allowed, make sure to pass undefined to className attribute in jsx if you don\'t want any class names - this will prevent rendering unnecessary class attribute to DOM'
+                        },
+                        {
+                            "codeSmellPattern": 'undefinedpx',
+                            "reportedError": 'undefinedpx is not allowed as attribute value'
+                        },
+                    ],
+                }],
+            },
+        },
+    ],
+};
+```

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,12 @@ const rules = fs
     .map((f) => f.replace(/\.js$/, ''));
 
 module.exports = {
+    processors: {
+        '.snap': {
+            preprocess: (source) => [source],
+            postprocess: (messages) => messages[0].filter((message) => message.ruleId.indexOf('snapshot') !== -1),
+        },
+    },
     rules: rules.reduce((ruleObj, rule) =>
         Object.assign(ruleObj, { [rule]: require(`./rules/${rule}`) })
         , {}),

--- a/src/index.js
+++ b/src/index.js
@@ -5,12 +5,12 @@ const path = require('path');
 
 const rules = fs
     .readdirSync(path.resolve(__dirname, 'rules'))
-    .map(f => f.replace(/\.js$/, ''));
+    .map((f) => f.replace(/\.js$/, ''));
 
 module.exports = {
     rules: rules.reduce((ruleObj, rule) =>
         Object.assign(ruleObj, { [rule]: require(`./rules/${rule}`) })
-    , {}),
+        , {}),
     configs: {
         recommended: {
             rules: {
@@ -19,8 +19,8 @@ module.exports = {
                 '@saxo/saxo/jsx-conditional-parens': 'error',
                 '@saxo/saxo/jsx-curly-spacing-opinionated': 'error',
                 '@saxo/saxo/jsx-enforce-prop-usage': 'warn',
-                '@saxo/saxo/jsx-enforce-spec-describe': 'warn'
-            }
-        }
-    }
+                '@saxo/saxo/jsx-enforce-spec-describe': 'warn',
+            },
+        },
+    },
 };

--- a/src/rules/clean-jest-snapshots.js
+++ b/src/rules/clean-jest-snapshots.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const reportOnViolation = ({
+    context, node, snapshot,
+}) => {
+    context.options[0].codeSmells.forEach(({ codeSmellPattern, reportedError }) => {
+        let startIndex = 0;
+        let currIndex;
+        while (
+            (currIndex = snapshot.value.raw.indexOf(codeSmellPattern, startIndex)) > -1
+        ) {
+            startIndex = currIndex + codeSmellPattern.length;
+            const lineWhereExpressionStarts = snapshot.loc.start.line;
+            const lineDelta = snapshot.value.raw.substring(0, currIndex).match(/\r?\n/g)
+                .length;
+            const problematicLine = lineWhereExpressionStarts + lineDelta;
+            context.report(
+                node,
+                {
+                    line: problematicLine,
+                },
+                reportedError
+            );
+        }
+    });
+};
+
+module.exports = {
+    create(context) {
+        if (!context.options[0] || !context.options[0].codeSmells) {
+            return {};
+        }
+
+        if (context.getFilename().endsWith('.snap')) {
+            return {
+                ExpressionStatement(node) {
+                    if (node.expression.right.type !== 'TemplateLiteral') {
+                        return;
+                    }
+
+                    reportOnViolation({
+                        context,
+                        node,
+                        snapshot: node.expression.right.quasis[0],
+                    });
+                },
+            };
+        } else if (context.getFilename().endsWith('.js')) {
+            return {
+                CallExpression(node) {
+                    const propertyName =
+                        node.callee.property && node.callee.property.name;
+                    if (
+                        propertyName === 'toMatchInlineSnapshot' ||
+                        propertyName === 'toThrowErrorMatchingInlineSnapshot'
+                    ) {
+                        let snapshot;
+
+                        // When snapshot is 1st argument:
+                        // * toMatchInlineSnapshot(snapshot?: string): void,
+                        // * toThrowErrorMatchingInlineSnapshot(snapshot?: string): void,
+                        if (
+                            node.arguments[0] &&
+                            node.arguments[0].type === 'TemplateLiteral'
+                        ) {
+                            snapshot = node.arguments[0].quasis[0];
+                        }
+
+                        // When snapshot is 2nd argument:
+                        // * toMatchInlineSnapshot(propertyMatchers?: any, snapshot?: string): void,
+                        if (
+                            node.arguments[1] &&
+                            node.arguments[1].type === 'TemplateLiteral'
+                        ) {
+                            snapshot = node.arguments[1].quasis[0];
+                        }
+
+                        if (!snapshot) {
+                            return;
+                        }
+
+                        reportOnViolation({
+                            context,
+                            node,
+                            snapshot,
+                        });
+                    }
+                },
+            };
+        }
+
+        return {};
+    },
+};

--- a/tests/lib/rules/clean-jest-snapshots.js
+++ b/tests/lib/rules/clean-jest-snapshots.js
@@ -1,0 +1,145 @@
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const assert = require('assert');
+const { RuleTester } = require('eslint');
+const rule = require('../../../src/rules/clean-jest-snapshots');
+const cleanJestSnapshots = rule.create;
+
+const ruleTester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 2015,
+    },
+});
+
+const codeSmells = [
+    {
+        codeSmellPattern: 'className=""',
+        reportedError: 'Empty value of className is not allowed, make sure to pass undefined to className attribute in jsx ' +
+        'if you don\'t want any class names - this will prevent rendering unnecessary class attribute to DOM',
+    },
+    {
+        codeSmellPattern: 'undefinedpx',
+        reportedError: 'undefinedpx is not allowed as attribute value',
+    },
+];
+
+ruleTester.run('clean-jest-snapshots', rule, {
+    valid: [
+        {
+            filename: 'mock.js',
+            code: `expect(something).toMatchInlineSnapshot(\`\n${'Array []'}\`);`,
+        },
+        {
+            filename: 'mock.js',
+            options: [{ codeSmells }],
+            code: `expect(something).toMatchInlineSnapshot(\`\n${'Array []'}\`);`,
+        },
+        {
+            filename: 'mock.js',
+            options: [{ codeSmells }],
+            code: `expect(something).toMatchInlineSnapshot(123,\`\n${'Array []'}\`);`,
+        },
+        {
+            filename: 'mock.js',
+            options: [{ codeSmells }],
+            code: `expect(something).toMatchInlineSnapshot(\`\n${'<Layout\nsize="small"\nclassName="foo-bar-baz"\n>'}\`);`,
+        },
+        {
+            filename: 'mock.js',
+            options: [{ codeSmells }],
+            code: `expect(something).toMatchInlineSnapshot(\`\n${'<Layout\nsize="small"\nwidth="123px"\n>'}\`);`,
+        },
+        {
+            filename: 'mock.js',
+            options: [{ codeSmells }],
+            code: `expect(something).unsupportedFunction(\`\n${'<Layout\nsize="small"\nclassName=""\n>'}\`);`,
+        },
+    ],
+    invalid: [
+        {
+            filename: 'mock.js',
+            options: [{ codeSmells }],
+            code: `expect(something).toMatchInlineSnapshot(\`\n${'<Layout\nsize="small"\nclassName=""\n>'}\`);`,
+            errors: [
+                {
+                    message: codeSmells[0].reportedError,
+                },
+            ],
+        },
+        {
+            filename: 'mock.js',
+            options: [{ codeSmells }],
+            code: `expect(something).toMatchInlineSnapshot(\`\n${'<Layout\nsize="small"\nwidth="undefinedpx"\n>'}\`);`,
+            errors: [
+                {
+                    message: codeSmells[1].reportedError,
+                },
+            ],
+        },
+        {
+            filename: 'mock.js',
+            options: [{ codeSmells }],
+            code: `expect(something).toMatchInlineSnapshot(123,\`\n${'<Layout\nsize="small"\nclassName=""\n>'}\`);`,
+            errors: [
+                {
+                    message: codeSmells[0].reportedError,
+                },
+            ],
+        },
+        {
+            filename: 'mock.js',
+            options: [{ codeSmells }],
+            code: `expect(something).toMatchInlineSnapshot(123,\`\n${'<Layout\nsize="small"\nwidth="undefinedpx"\n>'}\`);`,
+            errors: [
+                {
+                    message: codeSmells[1].reportedError,
+                },
+            ],
+        },
+        {
+            filename: 'mock.js',
+            options: [{ codeSmells }],
+            code: `expect(something).toThrowErrorMatchingInlineSnapshot(\`\n${'<Layout\nsize="small"\nclassName=""\n>'}\`);`,
+            errors: [
+                {
+                    message: codeSmells[0].reportedError,
+                },
+            ],
+        },
+        {
+            filename: 'mock.js',
+            options: [{ codeSmells }],
+            code: `expect(something).toThrowErrorMatchingInlineSnapshot(\`\n${'<Layout\nsize="small"\nwidth="undefinedpx"\n>'}\`);`,
+            errors: [
+                {
+                    message: codeSmells[1].reportedError,
+                },
+            ],
+        },
+    ],
+});
+
+describe('clean-jest-snapshots', () => {
+    it('should return an empty object for non snapshot files', () => {
+        const mockContext = {
+            getFilename: () => 'mock-component.jsx',
+            options: [{ codeSmells }],
+        };
+        const result = cleanJestSnapshots(mockContext);
+        assert.deepEqual(result, {});
+    });
+
+    it('should return an object with an ExpressionStatement function for snapshot files', () => {
+        const mockContext = {
+            getFilename: () => 'mock-component.jsx.snap',
+            options: [{ codeSmells }],
+        };
+
+        const result = cleanJestSnapshots(mockContext);
+        assert.equal(typeof result.ExpressionStatement, 'function');
+    });
+});


### PR DESCRIPTION
The eslint clean jest snapshots rule check for code smells in **.snap* files that contain [Jest snapshots](docs/rules/jsx-conditional-indent.md) and in **.js* files with [inline Jest snapshots](https://jestjs.io/docs/en/snapshot-testing#inline-snapshots) created using `toMatchInlineSnapshot` and `toThrowErrorMatchingInlineSnapshot` methods.

The rule must be configured with mandatory _codeSmells_ option array which allows to specify patterns in snapshots that will yield errors. Example:

```js
'saxo/clean-jest-snapshots': ['error', {
    codeSmells: [
        {
            codeSmellPattern: 'className=""',
            reportedError: 'Empty value of className is not allowed, make sure to pass undefined to className attribute in jsx if you don\'t want any class names - this will prevent rendering unnecessary class attribute to DOM'
        },
        {
            codeSmellPattern: 'undefinedpx',
            reportedError: 'undefinedpx is not allowed as attribute value'
        },
    ],
}],
```

For presented configuration the rule will thor error each time it encounters `className=""` and `undefinedpx` in snapshots.

The rule is not autofixable.