### PR TITLE
Add cypress viewport linting rules

### DIFF
--- a/docs/rules/cy-viewport-max.md
+++ b/docs/rules/cy-viewport-max.md
@@ -6,7 +6,6 @@ This rule enforces a limit on cypress viewport size. It does not account for ide
 ## Rule Details
 
 Examples of incorrect code for this rule:
-
 ```js
 /*eslint saxo/cy-viewport-max: ["error", { maxHeight: 1600, maxWidth: 1160 }]*/
 cy.viewport(1600, 1260);
@@ -23,7 +22,6 @@ cy.viewport(1600, 1700);
 ```
 
 Examples of correct code for this rule:
-
 ```js
 /*eslint saxo/cy-viewport-max: ["error", { maxHeight: 1600, maxWidth: 1160 }]*/
 cy.viewport(1600, 1160);

--- a/docs/rules/cy-viewport-max.md
+++ b/docs/rules/cy-viewport-max.md
@@ -1,0 +1,46 @@
+# Enforce a limit on cypress viewport size
+# cy-viewport-max
+
+This rule enforces a limit on cypress viewport size. It does not account for identifiers.
+
+## Rule Details
+
+Examples of incorrect code for this rule:
+
+```js
+/*eslint saxo/cy-viewport-max: ["error", { maxHeight: 1600, maxWidth: 1160 }]*/
+cy.viewport(1600, 1260);
+```
+
+```js
+/*eslint saxo/cy-viewport-max: ["error", { maxHeight: 1600 }]*/
+cy.viewport(1700, 1160);
+```
+
+```js
+/*eslint saxo/cy-viewport-max: ["error", { maxWidth: 1160 }]*/
+cy.viewport(1600, 1700);
+```
+
+Examples of correct code for this rule:
+
+```js
+/*eslint saxo/cy-viewport-max: ["error", { maxHeight: 1600, maxWidth: 1160 }]*/
+cy.viewport(1600, 1160);
+```
+
+```js
+/*eslint saxo/cy-viewport-max: ["error", { maxHeight: 1600 }]*/
+cy.viewport(1600, 1160);
+```
+
+```js
+/*eslint saxo/cy-viewport-max: ["error", { maxWidth: 1160 }]*/
+cy.viewport(1600, 1160);
+```
+
+## Options
+This rule has an object option, containing two properties.
+
+'maxHeight' enforces a limit on the height of the viewport.
+'maxWidth' enforces a limit on the width of the viewport.

--- a/docs/rules/cy-viewport-no-identifiers.md
+++ b/docs/rules/cy-viewport-no-identifiers.md
@@ -6,7 +6,6 @@ This rule disallows the use of identifiers when setting cypress viewport.
 ## Rule Details
 
 Examples of incorrect code for this rule:
-
 ```js
 /*eslint saxo/cy-viewport-no-identifiers: "error"*/
 cy.viewport(height, 1260);
@@ -24,7 +23,6 @@ cy.viewport('macbook-13', orientation);
 
 
 Examples of correct code for this rule:
-
 ```js
 /*eslint saxo/cy-viewport-no-identifiers: "error"*/
 cy.viewport('macbook-13', 'landscape', options);

--- a/docs/rules/cy-viewport-no-identifiers.md
+++ b/docs/rules/cy-viewport-no-identifiers.md
@@ -1,0 +1,41 @@
+# Disallow identifiers as cypress viewport parameters
+# cy-viewport-no-identifiers
+
+This rule disallows the use of identifiers when setting cypress viewport.
+
+## Rule Details
+
+Examples of incorrect code for this rule:
+
+```js
+/*eslint saxo/cy-viewport-no-identifiers: "error"*/
+cy.viewport(height, 1260);
+```
+
+```js
+/*eslint saxo/cy-viewport-no-identifiers: "error"*/
+cy.viewport(preset, 'landscape');
+```
+
+```js
+/*eslint saxo/cy-viewport-no-identifiers: "error"*/
+cy.viewport('macbook-13', orientation);
+```
+
+
+Examples of correct code for this rule:
+
+```js
+/*eslint saxo/cy-viewport-no-identifiers: "error"*/
+cy.viewport('macbook-13', 'landscape', options);
+```
+
+```js
+/*eslint saxo/cy-viewport-no-identifiers: "error"*/
+cy.viewport(1600, 1160, options);
+```
+
+```js
+/*eslint saxo/cy-viewport-no-identifiers: "error"*/
+cy.viewport('macbook-13');
+```

--- a/docs/rules/cy-viewport-presets.md
+++ b/docs/rules/cy-viewport-presets.md
@@ -6,21 +6,8 @@ This rule enforces the use of specific presets when setting cypress viewport, or
 ## Rule Details
 
 Examples of incorrect code for this rule:
-
 ```js
-/*eslint saxo/cy-viewport-presets: ["error", ['phone', 'tablet', 'desktop']]*/
-cy.viewport('phone', 'landscape');
-```
-
-```js
-/*eslint saxo/cy-viewport-presets: ["error", ['tablet']]*/
-cy.viewport('tablet');
-```
-
-Examples of correct code for this rule:
-
-```js
-/*eslint saxo/cy-viewport-presets: ["error", ['phone', 'tablet', 'desktop']]*/
+/*eslint saxo/cy-viewport-presets: ["error", { allowed: ['phone', 'tablet', 'desktop'] }*/
 cy.viewport('iphone-6');
 ```
 
@@ -29,5 +16,19 @@ cy.viewport('iphone-6');
 cy.viewport('phone');
 ```
 
+Examples of correct code for this rule:
+```js
+/*eslint saxo/cy-viewport-presets: ["error", { allowed: ['phone', 'tablet', 'desktop'] }*/
+cy.viewport('phone', 'landscape');
+```
+
+```js
+/*eslint saxo/cy-viewport-presets: ["error", { allowed: ['tablet'] }*/
+cy.viewport('tablet');
+```
+
+
 ## Options
-This rule has an array option containing the allowed presets. If none are defined no presets will be allowed.
+This rule has an object option, containing one property. 
+
+'allowed' contains the presets to enforce. If the array is empty, presets are disallowed.

--- a/docs/rules/cy-viewport-presets.md
+++ b/docs/rules/cy-viewport-presets.md
@@ -12,7 +12,7 @@ cy.viewport('iphone-6');
 ```
 
 ```js
-/*eslint saxo/cy-viewport-presets: ["error"]*/
+/*eslint saxo/cy-viewport-presets: "error"*/
 cy.viewport('phone');
 ```
 

--- a/docs/rules/cy-viewport-presets.md
+++ b/docs/rules/cy-viewport-presets.md
@@ -1,0 +1,33 @@
+# Enforce specific cypress viewport presets
+# cy-viewport-presets
+
+This rule enforces the use of specific presets when setting cypress viewport, or disallows them entirely.
+
+## Rule Details
+
+Examples of incorrect code for this rule:
+
+```js
+/*eslint saxo/cy-viewport-presets: ["error", ['phone', 'tablet', 'desktop']]*/
+cy.viewport('phone', 'landscape');
+```
+
+```js
+/*eslint saxo/cy-viewport-presets: ["error", ['tablet']]*/
+cy.viewport('tablet');
+```
+
+Examples of correct code for this rule:
+
+```js
+/*eslint saxo/cy-viewport-presets: ["error", ['phone', 'tablet', 'desktop']]*/
+cy.viewport('iphone-6');
+```
+
+```js
+/*eslint saxo/cy-viewport-presets: ["error"]*/
+cy.viewport('phone');
+```
+
+## Options
+This rule has an array option containing the allowed presets. If none are defined no presets will be allowed.

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ module.exports = {
         recommended: {
             rules: {
                 '@saxo/saxo/cy-viewport-max': ['error', { maxHeight: 1600, maxWidth: 1160 }],
-                '@saxo/saxo/cy-viewport-presets': ['error', ['phone', 'tablet', 'desktop']],
+                '@saxo/saxo/cy-viewport-presets': ['error', { allowed: ['phone', 'tablet', 'desktop'] }],
                 '@saxo/saxo/cy-viewport-no-identifiers': 'error',
                 '@saxo/saxo/jsx-conditional-indent': 'error',
                 '@saxo/saxo/jsx-conditional-newline': 'error',

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,9 @@ module.exports = {
     configs: {
         recommended: {
             rules: {
+                '@saxo/saxo/cy-viewport-max': ['error', { maxHeight: 1600, maxWidth: 1160 }],
+                '@saxo/saxo/cy-viewport-presets': ['error', ['phone', 'tablet', 'desktop']],
+                '@saxo/saxo/cy-viewport-no-identifiers': 'error',
                 '@saxo/saxo/jsx-conditional-indent': 'error',
                 '@saxo/saxo/jsx-conditional-newline': 'error',
                 '@saxo/saxo/jsx-conditional-parens': 'error',

--- a/src/rules/cy-viewport-max.js
+++ b/src/rules/cy-viewport-max.js
@@ -1,0 +1,65 @@
+'use strict';
+
+module.exports = {
+    meta: {
+        docs: {
+            description: 'enforce a limit on cypress viewport size',
+            recommended: false,
+        },
+        schema: [
+            {
+                type: 'object',
+                properties: {
+                    maxHeight: {
+                        type: 'number',
+                    },
+                    maxWidth: {
+                        type: 'number',
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
+        messages: {
+            tooLargeViewport: 'Do not use viewport sizes larger than {{height}}x{{width}}',
+            tooHighViewport: 'Do not use a viewport height larger than {{height}}',
+            tooWideViewport: 'Do not use a viewport width larger than {{width}}',
+        },
+    },
+    create(context) {
+        const options = context.options[0] || {};
+        const maxHeight = options.maxHeight;
+        const maxWidth = options.maxWidth;
+
+        return {
+            CallExpression(node) {
+                if (
+                    node.callee.object.name === 'cy' &&
+                    node.callee.property.name === 'viewport' &&
+                    node.arguments.length > 1 &&
+                    typeof node.arguments[0].value !== 'string'
+                ) {
+                    if (maxHeight && maxWidth && (node.arguments[0].value > maxHeight || node.arguments[1].value > maxWidth)) {
+                        context.report({
+                            node,
+                            messageId: 'tooLargeViewport',
+                            data: { height: maxHeight, width: maxWidth },
+                        });
+                    } else if (maxHeight && node.arguments[0].value > maxHeight) {
+                        context.report({
+                            node,
+                            messageId: 'tooHighViewport',
+                            data: { height: maxHeight },
+                        });
+                    } else if (maxWidth && node.arguments[1].value > maxWidth) {
+                        context.report({
+                            node,
+                            messageId: 'tooWideViewport',
+                            data: { width: maxWidth },
+                        });
+                    }
+                }
+            },
+        };
+    },
+};

--- a/src/rules/cy-viewport-no-identifiers.js
+++ b/src/rules/cy-viewport-no-identifiers.js
@@ -1,0 +1,31 @@
+'use strict';
+
+module.exports = {
+    meta: {
+        docs: {
+            description: 'disallow identifiers as cypress viewport parameters',
+            recommended: false,
+        },
+        schema: [],
+        messages: {
+            noIdentifiers: 'Do not use identifiers as viewport parameters',
+        },
+    },
+    create(context) {
+        return {
+            CallExpression(node) {
+                if (
+                    node.callee.object.name === 'cy' &&
+                    node.callee.property.name === 'viewport' &&
+                    (node.arguments[0].type === 'Identifier' ||
+                    (node.arguments.length > 1 && node.arguments[1].type === 'Identifier'))
+                ) {
+                    context.report({
+                        node,
+                        messageId: 'noIdentifiers',
+                    });
+                }
+            },
+        };
+    },
+};

--- a/src/rules/cy-viewport-presets.js
+++ b/src/rules/cy-viewport-presets.js
@@ -1,0 +1,45 @@
+'use strict';
+
+module.exports = {
+    meta: {
+        docs: {
+            description: 'enforce specific cypress viewport presets',
+            recommended: false,
+        },
+        schema: [
+            {
+                type: 'array',
+            },
+        ],
+        messages: {
+            unSupportedPresets: 'Only use supported viewport presets: {{allowedPresets}}',
+            noSupportedPresets: 'Do not use presets when setting cypress viewport',
+        },
+    },
+    create(context) {
+        const presets = context.options[0] || [];
+
+        return {
+            CallExpression(node) {
+                if (
+                    node.callee.object.name === 'cy' &&
+                    node.callee.property.name === 'viewport' &&
+                    typeof node.arguments[0].value === 'string'
+                ) {
+                    if (presets.length === 0) {
+                        context.report({
+                            node,
+                            messageId: 'noSupportedPresets',
+                        });
+                    } else if (presets.indexOf(node.arguments[0].value) < 0) {
+                        context.report({
+                            node,
+                            messageId: 'unSupportedPresets',
+                            data: { allowedPresets: presets.join(', ') },
+                        });
+                    }
+                }
+            },
+        };
+    },
+};

--- a/src/rules/cy-viewport-presets.js
+++ b/src/rules/cy-viewport-presets.js
@@ -8,16 +8,24 @@ module.exports = {
         },
         schema: [
             {
-                type: 'array',
+                type: 'object',
+                properties: {
+                    allowed: {
+                        type: 'array',
+                        default: [],
+                    },
+                },
+                additionalProperties: false,
             },
         ],
         messages: {
-            unSupportedPresets: 'Only use supported viewport presets: {{allowedPresets}}',
+            unSupportedPresets: 'Only use supported viewport presets: {{presets}}',
             noSupportedPresets: 'Do not use presets when setting cypress viewport',
         },
     },
     create(context) {
-        const presets = context.options[0] || [];
+        const options = context.options[0] || {};
+        const allowed = options.allowed || [];
 
         return {
             CallExpression(node) {
@@ -26,16 +34,16 @@ module.exports = {
                     node.callee.property.name === 'viewport' &&
                     typeof node.arguments[0].value === 'string'
                 ) {
-                    if (presets.length === 0) {
+                    if (allowed.length === 0) {
                         context.report({
                             node,
                             messageId: 'noSupportedPresets',
                         });
-                    } else if (presets.indexOf(node.arguments[0].value) < 0) {
+                    } else if (allowed.indexOf(node.arguments[0].value) < 0) {
                         context.report({
                             node,
                             messageId: 'unSupportedPresets',
-                            data: { allowedPresets: presets.join(', ') },
+                            data: { presets: allowed.join(', ') },
                         });
                     }
                 }

--- a/tests/lib/rules/cy-viewport-max.js
+++ b/tests/lib/rules/cy-viewport-max.js
@@ -1,0 +1,88 @@
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const { RuleTester } = require('eslint');
+const rule = require('../../../src/rules/cy-viewport-max');
+const parserOptions = {
+    sourceType: 'module',
+    ecmaVersion: 6,
+    ecmaFeatures: {
+        jsx: true,
+    },
+};
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({ parserOptions });
+ruleTester.run('cy-viewport-max', rule, {
+    valid: [{
+        code: 'yc.viewport(1750, 1400)',
+        options: [{ maxHeight: 1700, maxWidth: 1300 }],
+    }, {
+        code: 'cy.viewport("phone")',
+        options: [{ maxHeight: 1700, maxWidth: 1300 }],
+    }, {
+        code: 'cy.viewport("phone", "landscape")',
+        options: [{ maxHeight: 1700, maxWidth: 1300 }],
+    }, {
+        code: 'cy.viewport(1650, 1200)',
+        options: [{ maxHeight: 1700, maxWidth: 1300 }],
+    }, {
+        code: 'cy.viewport(50, 200)',
+        options: [{ maxHeight: 200, maxWidth: 300 }],
+    }, {
+        code: 'cy.viewport(1100, 2000)',
+        options: [{ maxHeight: 1200 }],
+    }, {
+        code: 'cy.viewport(2000, 1100)',
+        options: [{ maxWidth: 1200 }],
+    }],
+    invalid: [{
+        code: 'cy.viewport(1400, 900)',
+        options: [{ maxHeight: 1300, maxWidth: 700 }],
+        errors: [{
+            messageId: 'tooLargeViewport',
+            data: { height: 1300, width: 700 },
+        }],
+    }, {
+        code: 'cy.viewport(1600, 1160)',
+        options: [{ maxHeight: 8000, maxWidth: 20 }],
+        errors: [{
+            messageId: 'tooLargeViewport',
+            data: { height: 8000, width: 20 },
+        }],
+    }, {
+        code: 'cy.viewport(height, 1200)',
+        options: [{ maxHeight: 1600, maxWidth: 1160 }],
+        errors: [{
+            messageId: 'tooLargeViewport',
+            data: { height: 1600, width: 1160 },
+        }],
+    }, {
+        code: 'cy.viewport(1700, width)',
+        options: [{ maxHeight: 1600, maxWidth: 1160 }],
+        errors: [{
+            messageId: 'tooLargeViewport',
+            data: { height: 1600, width: 1160 },
+        }],
+    }, {
+        code: 'cy.viewport(1600, 1160)',
+        options: [{ maxHeight: 800 }],
+        errors: [{
+            messageId: 'tooHighViewport',
+            data: { height: 800 },
+        }],
+    }, {
+        code: 'cy.viewport(1600, 1160)',
+        options: [{ maxWidth: 800 }],
+        errors: [{
+            messageId: 'tooWideViewport',
+            data: { width: 800 },
+        }],
+    }],
+});

--- a/tests/lib/rules/cy-viewport-no-identifiers.js
+++ b/tests/lib/rules/cy-viewport-no-identifiers.js
@@ -1,0 +1,57 @@
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const { RuleTester } = require('eslint');
+const rule = require('../../../src/rules/cy-viewport-no-identifiers');
+const parserOptions = {
+    sourceType: 'module',
+    ecmaVersion: 6,
+    ecmaFeatures: {
+        jsx: true,
+    },
+};
+
+const noIdentifiersError = { messageId: 'noIdentifiers' };
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({ parserOptions });
+ruleTester.run('cy-viewport-no-identifiers', rule, {
+    valid: [{
+        code: 'yc.viewport(height, width)',
+    }, {
+        code: 'cy.viewport(1650, 1200)',
+    }, {
+        code: 'cy.viewport(1650, 1200, options)',
+    }, {
+        code: 'cy.viewport("macbook-13")',
+    }, {
+        code: 'cy.viewport("macbook-13", "landscape")',
+    }, {
+        code: 'cy.viewport("macbook-13", "landscape", options)',
+    }],
+    invalid: [{
+        code: 'cy.viewport(height, 900)',
+        errors: [noIdentifiersError],
+    }, {
+        code: 'cy.viewport(1600, width)',
+        errors: [noIdentifiersError],
+    }, {
+        code: 'cy.viewport(height, width)',
+        errors: [noIdentifiersError],
+    }, {
+        code: 'cy.viewport(preset)',
+        errors: [noIdentifiersError],
+    }, {
+        code: 'cy.viewport(preset, "landscape")',
+        errors: [noIdentifiersError],
+    }, {
+        code: 'cy.viewport("preset", orientation)',
+        errors: [noIdentifiersError],
+    }],
+});

--- a/tests/lib/rules/cy-viewport-presets.js
+++ b/tests/lib/rules/cy-viewport-presets.js
@@ -24,13 +24,13 @@ ruleTester.run('cy-viewport-presets', rule, {
         code: 'yc.viewport("phone")',
     }, {
         code: 'cy.viewport("phone")',
-        options: [['phone', 'tablet', 'desktop']],
+        options: [{ allowed: ['phone', 'tablet', 'desktop'] }],
     }, {
         code: 'cy.viewport("tablet")',
-        options: [['tablet']],
+        options: [{ allowed: ['tablet'] }],
     }, {
         code: 'cy.viewport(1600, 1160)',
-        options: [['tablet']],
+        options: [{ allowed: ['tablet'] }],
     }, {
         code: 'cy.viewport(1600, 1160)',
     }, {
@@ -38,10 +38,10 @@ ruleTester.run('cy-viewport-presets', rule, {
     }],
     invalid: [{
         code: 'cy.viewport("rocket")',
-        options: [['phone', 'tablet', 'desktop']],
+        options: [{ allowed: ['phone', 'tablet', 'desktop'] }],
         errors: [{
             messageId: 'unSupportedPresets',
-            data: { allowedPresets: 'phone, tablet, desktop' },
+            data: { presets: 'phone, tablet, desktop' },
         }],
     }, {
         code: 'cy.viewport("phone")',

--- a/tests/lib/rules/cy-viewport-presets.js
+++ b/tests/lib/rules/cy-viewport-presets.js
@@ -1,0 +1,52 @@
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const { RuleTester } = require('eslint');
+const rule = require('../../../src/rules/cy-viewport-presets');
+const parserOptions = {
+    sourceType: 'module',
+    ecmaVersion: 6,
+    ecmaFeatures: {
+        jsx: true,
+    },
+};
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({ parserOptions });
+ruleTester.run('cy-viewport-presets', rule, {
+    valid: [{
+        code: 'yc.viewport("phone")',
+    }, {
+        code: 'cy.viewport("phone")',
+        options: [['phone', 'tablet', 'desktop']],
+    }, {
+        code: 'cy.viewport("tablet")',
+        options: [['tablet']],
+    }, {
+        code: 'cy.viewport(1600, 1160)',
+        options: [['tablet']],
+    }, {
+        code: 'cy.viewport(1600, 1160)',
+    }, {
+        code: 'cy.viewport(preset)',
+    }],
+    invalid: [{
+        code: 'cy.viewport("rocket")',
+        options: [['phone', 'tablet', 'desktop']],
+        errors: [{
+            messageId: 'unSupportedPresets',
+            data: { allowedPresets: 'phone, tablet, desktop' },
+        }],
+    }, {
+        code: 'cy.viewport("phone")',
+        errors: [{
+            messageId: 'noSupportedPresets',
+        }],
+    }],
+});


### PR DESCRIPTION
Add three rules used with the cypress viewport method:
- Enforce a limit on cypress viewport size.
- Disallow identifiers as cypress viewport parameters.
- Enforce specific cypress viewport presets.
