### PR TITLE
Check for callee object and fix widthXheight

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ module.exports = {
     },
     rules: rules.reduce((ruleObj, rule) =>
         Object.assign(ruleObj, { [rule]: require(`./rules/${rule}`) })
-    , {}),
+        , {}),
     configs: {
         recommended: {
             rules: {

--- a/src/rules/cy-viewport-max.js
+++ b/src/rules/cy-viewport-max.js
@@ -21,7 +21,7 @@ module.exports = {
             },
         ],
         messages: {
-            tooLargeViewport: 'Do not use viewport sizes larger than {{height}}x{{width}}',
+            tooLargeViewport: 'Do not use viewport sizes larger than {{width}}x{{height}}',
             tooHighViewport: 'Do not use a viewport height larger than {{height}}',
             tooWideViewport: 'Do not use a viewport width larger than {{width}}',
         },
@@ -34,28 +34,29 @@ module.exports = {
         return {
             CallExpression(node) {
                 if (
+                    node.callee.object &&
                     node.callee.object.name === 'cy' &&
                     node.callee.property.name === 'viewport' &&
                     node.arguments.length > 1 &&
                     typeof node.arguments[0].value !== 'string'
                 ) {
-                    if (maxHeight && maxWidth && (node.arguments[0].value > maxHeight || node.arguments[1].value > maxWidth)) {
+                    if (maxWidth && maxHeight && (node.arguments[0].value > maxWidth || node.arguments[1].value > maxHeight)) {
                         context.report({
                             node,
                             messageId: 'tooLargeViewport',
-                            data: { height: maxHeight, width: maxWidth },
+                            data: { height: maxWidth, width: maxHeight },
                         });
-                    } else if (maxHeight && node.arguments[0].value > maxHeight) {
-                        context.report({
-                            node,
-                            messageId: 'tooHighViewport',
-                            data: { height: maxHeight },
-                        });
-                    } else if (maxWidth && node.arguments[1].value > maxWidth) {
+                    } else if (maxWidth && node.arguments[0].value > maxWidth) {
                         context.report({
                             node,
                             messageId: 'tooWideViewport',
                             data: { width: maxWidth },
+                        });
+                    } else if (maxHeight && node.arguments[1].value > maxHeight) {
+                        context.report({
+                            node,
+                            messageId: 'tooHighViewport',
+                            data: { height: maxHeight },
                         });
                     }
                 }

--- a/src/rules/cy-viewport-no-identifiers.js
+++ b/src/rules/cy-viewport-no-identifiers.js
@@ -15,6 +15,7 @@ module.exports = {
         return {
             CallExpression(node) {
                 if (
+                    node.callee.object &&
                     node.callee.object.name === 'cy' &&
                     node.callee.property.name === 'viewport' &&
                     (node.arguments[0].type === 'Identifier' ||

--- a/src/rules/cy-viewport-presets.js
+++ b/src/rules/cy-viewport-presets.js
@@ -30,6 +30,7 @@ module.exports = {
         return {
             CallExpression(node) {
                 if (
+                    node.callee.object &&
                     node.callee.object.name === 'cy' &&
                     node.callee.property.name === 'viewport' &&
                     typeof node.arguments[0].value === 'string'

--- a/tests/lib/rules/cy-viewport-max.js
+++ b/tests/lib/rules/cy-viewport-max.js
@@ -22,60 +22,53 @@ const ruleTester = new RuleTester({ parserOptions });
 ruleTester.run('cy-viewport-max', rule, {
     valid: [{
         code: 'yc.viewport(1750, 1400)',
-        options: [{ maxHeight: 1700, maxWidth: 1300 }],
+        options: [{ maxWidth: 1700, maxHeight: 1300 }],
     }, {
         code: 'cy.viewport("phone")',
-        options: [{ maxHeight: 1700, maxWidth: 1300 }],
+        options: [{ maxWidth: 1700, maxHeight: 1300 }],
     }, {
         code: 'cy.viewport("phone", "landscape")',
-        options: [{ maxHeight: 1700, maxWidth: 1300 }],
+        options: [{ maxWidth: 1700, maxHeight: 1300 }],
     }, {
         code: 'cy.viewport(1650, 1200)',
-        options: [{ maxHeight: 1700, maxWidth: 1300 }],
+        options: [{ maxWidth: 1700, maxHeight: 1300 }],
     }, {
         code: 'cy.viewport(50, 200)',
-        options: [{ maxHeight: 200, maxWidth: 300 }],
+        options: [{ maxWidth: 200, maxHeight: 300 }],
     }, {
         code: 'cy.viewport(1100, 2000)',
-        options: [{ maxHeight: 1200 }],
+        options: [{ maxWidth: 1200 }],
     }, {
         code: 'cy.viewport(2000, 1100)',
-        options: [{ maxWidth: 1200 }],
+        options: [{ maxHeight: 1200 }],
     }],
     invalid: [{
         code: 'cy.viewport(1400, 900)',
-        options: [{ maxHeight: 1300, maxWidth: 700 }],
+        options: [{ maxWidth: 1300, maxHeight: 700 }],
         errors: [{
             messageId: 'tooLargeViewport',
             data: { height: 1300, width: 700 },
         }],
     }, {
         code: 'cy.viewport(1600, 1160)',
-        options: [{ maxHeight: 8000, maxWidth: 20 }],
+        options: [{ maxWidth: 8000, maxHeight: 20 }],
         errors: [{
             messageId: 'tooLargeViewport',
             data: { height: 8000, width: 20 },
         }],
     }, {
-        code: 'cy.viewport(height, 1200)',
-        options: [{ maxHeight: 1600, maxWidth: 1160 }],
+        code: 'cy.viewport(width, 1200)',
+        options: [{ maxWidth: 1600, maxHeight: 1160 }],
         errors: [{
             messageId: 'tooLargeViewport',
             data: { height: 1600, width: 1160 },
         }],
     }, {
-        code: 'cy.viewport(1700, width)',
-        options: [{ maxHeight: 1600, maxWidth: 1160 }],
+        code: 'cy.viewport(1700, height)',
+        options: [{ maxWidth: 1600, maxHeight: 1160 }],
         errors: [{
             messageId: 'tooLargeViewport',
             data: { height: 1600, width: 1160 },
-        }],
-    }, {
-        code: 'cy.viewport(1600, 1160)',
-        options: [{ maxHeight: 800 }],
-        errors: [{
-            messageId: 'tooHighViewport',
-            data: { height: 800 },
         }],
     }, {
         code: 'cy.viewport(1600, 1160)',
@@ -83,6 +76,13 @@ ruleTester.run('cy-viewport-max', rule, {
         errors: [{
             messageId: 'tooWideViewport',
             data: { width: 800 },
+        }],
+    }, {
+        code: 'cy.viewport(1600, 1160)',
+        options: [{ maxHeight: 800 }],
+        errors: [{
+            messageId: 'tooHighViewport',
+            data: { height: 800 },
         }],
     }],
 });


### PR DESCRIPTION
CallExpressions are not always objects, and the viewport method takes width as first argument, not height. To great blunders, fixed in this PR.