### PR TITLE
Add cy-pause to prevent merging cy.pause()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.4.3] - 2019-06-03
+- Add cy-pause to prevent cy.pause() from being committed to master
+
 ## [1.4.2] - 2019-05-21
 - Fix cy-viewport rules to not break on calls without arguments
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-saxo",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "author": "Saxo Bank",
   "description": "ESLint rules created for Saxo Bank",
   "main": "src/index.js",

--- a/src/astUtils.js
+++ b/src/astUtils.js
@@ -42,3 +42,12 @@ exports.isParenthesised = function isParenthesised(sourceCode, node) {
         previousToken.value === '(' && previousToken.range[1] <= node.range[0] &&
         nextToken.value === ')' && nextToken.range[0] >= node.range[1];
 };
+
+// Gets the top level object name of a chain.
+exports.getObjectName = (node) => {
+    if (node.object.type === 'Identifier') {
+        return node.object.name;
+    }
+
+    return exports.getObjectName(node.object.callee);
+};

--- a/src/index.js
+++ b/src/index.js
@@ -16,13 +16,14 @@ module.exports = {
     },
     rules: rules.reduce((ruleObj, rule) =>
         Object.assign(ruleObj, { [rule]: require(`./rules/${rule}`) })
-        , {}),
+    , {}),
     configs: {
         recommended: {
             rules: {
                 '@saxo/saxo/cy-viewport-max': ['error', { maxWidth: 1600, maxHeight: 1160 }],
                 '@saxo/saxo/cy-viewport-presets': ['error', { allowed: ['phone', 'tablet', 'desktop'] }],
                 '@saxo/saxo/cy-viewport-literals': 'error',
+                '@saxo/saxo/cy-pause': 'error',
                 '@saxo/saxo/jsx-conditional-indent': 'error',
                 '@saxo/saxo/jsx-conditional-newline': 'error',
                 '@saxo/saxo/jsx-conditional-parens': 'error',

--- a/src/rules/cy-pause.js
+++ b/src/rules/cy-pause.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const { getObjectName } = require('../astUtils');
+
+module.exports = {
+    meta: {
+        docs: {
+            description: 'cy.pause() stops commands from running to allow interaction, usually this isn\'t something we want to merge',
+            recommended: false,
+        },
+    },
+    create(context) {
+        return {
+            ExpressionStatement(node) {
+                if (node.expression.callee.property.name === 'pause' && getObjectName(node.expression.callee) === 'cy') {
+                    context.report({
+                        node,
+                        message: 'Do not use cy.pause()',
+                    });
+                }
+            },
+        };
+    },
+};

--- a/tests/lib/rules/cy-pause.js
+++ b/tests/lib/rules/cy-pause.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../../../src/rules/cy-pause');
+
+const parserOptions = {
+    sourceType: 'module',
+    ecmaVersion: 6,
+    ecmaFeatures: {
+        jsx: true,
+    },
+};
+
+const doNotUseCyPauseError = { message: 'Do not use cy.pause()' };
+
+const ruleTester = new RuleTester({ parserOptions });
+ruleTester.run('cy-pause', rule, {
+    valid: [],
+    invalid: [{
+        code: 'cy.pause()',
+        errors: [doNotUseCyPauseError],
+    }, {
+        code: 'cy.foo().pause()',
+        errors: [doNotUseCyPauseError],
+    }, {
+        code: 'cy.foo().bar().pause()',
+        errors: [doNotUseCyPauseError],
+    }],
+});


### PR DESCRIPTION
`cy.pause()` was accidentally committed to the codebase. This is handy when debugging locally but not something we want to merge.

Lint against it, including use in a chain