### PR TITLE
Fix `cy.pause` linting failing on non singular call expressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-saxo",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "author": "Saxo Bank",
   "description": "ESLint rules created for Saxo Bank",
   "main": "src/index.js",

--- a/src/rules/cy-pause.js
+++ b/src/rules/cy-pause.js
@@ -12,7 +12,7 @@ module.exports = {
     create(context) {
         return {
             ExpressionStatement(node) {
-                if (node.expression.callee.property.name === 'pause' && getObjectName(node.expression.callee) === 'cy') {
+                if (node.expression.callee.type === 'MemberExpression' && node.expression.callee.property.name === 'pause' && getObjectName(node.expression.callee) === 'cy') {
                     context.report({
                         node,
                         message: 'Do not use cy.pause()',


### PR DESCRIPTION
Previously this was assuming that all nodes were nested member expressions, e.g. `cy.pause()`, `cy.foo().pause()`.

This assumption caused an error for singular call expressions, e.g. `describe(...)`