### PR TITLE
Be more thorough checking cy.pause()

### DIFF
--- a/src/astUtils.js
+++ b/src/astUtils.js
@@ -44,10 +44,17 @@ exports.isParenthesised = function isParenthesised(sourceCode, node) {
 };
 
 // Gets the top level object name of a chain.
-exports.getObjectName = (node) => {
-    if (node.object.type === 'Identifier') {
-        return node.object.name;
-    }
+exports.firstMemberExpression = (node) => {
+    switch (node.type) {
+        case 'MemberExpression':
+            // one.two.three
+            // ^~~~~~~
+            return exports.firstMemberExpression(node.object);
 
-    return exports.getObjectName(node.object.callee);
+        case 'CallExpression':
+            // one.two.three()
+            // ^~~~~~~~~~~~~
+            return exports.firstMemberExpression(node.callee);
+    }
+    return node;
 };

--- a/src/rules/cy-pause.js
+++ b/src/rules/cy-pause.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { getObjectName } = require('../astUtils');
+const { firstMemberExpression } = require('../astUtils');
 
 module.exports = {
     meta: {
@@ -12,12 +12,52 @@ module.exports = {
     create(context) {
         return {
             ExpressionStatement(node) {
-                if (node.expression.callee.type === 'MemberExpression' && node.expression.callee.property.name === 'pause' && getObjectName(node.expression.callee) === 'cy') {
-                    context.report({
-                        node,
-                        message: 'Do not use cy.pause()',
-                    });
+                // <something>()
+                //            ^~
+                if (node.expression.type !== 'CallExpression') {
+                    return;
                 }
+
+                // <something>.target()
+                // ^~~~~~~~~~~~~~~~~~
+                const { callee } = node.expression;
+                if (callee.type !== 'MemberExpression') {
+                    return;
+                }
+
+                // <something>.pause()
+                //             ^~~~~
+                const { property: { name: memberName } } = callee;
+                if (memberName !== 'pause') {
+                    return;
+                }
+
+                // object.member().member.pause()
+                // ^~~~~~
+                const dotStart = firstMemberExpression(callee);
+                if (!dotStart) {
+                    return;
+                }
+
+                // object.member.pause()
+                // ^~~~~~ accept
+                // (b ? x : y).member.pause()
+                // ^~~~~~~~~~~ ignore
+                if (dotStart.type !== 'Identifier') {
+                    return;
+                }
+
+                // cy.pause()
+                // ^~ accept
+                const { name: objectName } = dotStart;
+                if (objectName !== 'cy') {
+                    return;
+                }
+
+                context.report({
+                    node,
+                    message: 'Do not use cy.pause()',
+                });
             },
         };
     },

--- a/tests/lib/rules/cy-pause.js
+++ b/tests/lib/rules/cy-pause.js
@@ -6,16 +6,19 @@ const rule = require('../../../src/rules/cy-pause');
 const parserOptions = {
     sourceType: 'module',
     ecmaVersion: 6,
-    ecmaFeatures: {
-        jsx: true,
-    },
 };
 
 const doNotUseCyPauseError = { message: 'Do not use cy.pause()' };
 
 const ruleTester = new RuleTester({ parserOptions });
 ruleTester.run('cy-pause', rule, {
-    valid: [],
+    valid: [{
+        code: 'other.pause()',
+    }, {
+        code: 'properties.pause',
+    }, {
+        code: 'pause()',
+    }],
     invalid: [{
         code: 'cy.pause()',
         errors: [doNotUseCyPauseError],


### PR DESCRIPTION
We now check for member expressions  e.g. `cy.member.pause()` as
well as `cy.member().pause()`. This comes as a side effect of how
we now walk an expression tree.

Walking the expression tree was changed to fix a few cases where
we were accessing values that weren't necessarily available on the
expression 'union'.