### PR TITLE
Enforce exported string constants are typed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.6.0] - 2019-08-12
-- Enforce exported string constants are typed
+- Enforce exported string constants are typed (string-constant-types)
 
 ## [1.5.0] - 2019-06-18
 - Add no-cy-pause rule

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.6.0] - 2019-08-12
+- Enforce exported string constants are typed
+
 ## [1.5.0] - 2019-06-18
 - Add no-cy-pause rule
 

--- a/docs/rules/string-constant-types.md
+++ b/docs/rules/string-constant-types.md
@@ -7,28 +7,36 @@ This is important when creating enums of string values, as omitting even one typ
 
 ## Examples of incorrect code for this rule:
 
+❌ Exported string constants that aren't typed
+
 ```js
-/* eslint saxo/string-constant-types: "error" */
 // @flow
+/* eslint saxo/string-constant-types: "error" */
 export const foo = 'foo'
 ```
 
 ## Examples of correct code for this rule:
 
+✅ Exported string constants that aren't typed, but are in a non flow annotated file
+
 ```js
-/* eslint saxo/string-constant-types: "error" */
 /* eslint-disable flowtype/require-valid-file-annotation */
+/* eslint saxo/string-constant-types: "error" */
 export const foo = 'foo'
 ```
 
+✅ Already typed exported constants
+
 ```js
-/* eslint saxo/string-constant-types: "error" */
 // @flow
+/* eslint saxo/string-constant-types: "error" */
 export const foo: 'foo' = 'foo'
 ```
 
-```js
-/* eslint saxo/string-constant-types: "error" */
+✅ Non exported constants
 
+```js
+// @flow
+/* eslint saxo/string-constant-types: "error" */
 const foo = 'foo'
 ```

--- a/docs/rules/string-constant-types.md
+++ b/docs/rules/string-constant-types.md
@@ -1,0 +1,34 @@
+# Enforce string constants are explicitly typed
+# string-constant-types
+
+This rule enforces exported string constants are explicitly typed if they are in a flow annotated file.
+
+This is important when creating enums of string values, as omitting even one type reverts the type to `string` (`'foo' | 'bar' | string` -> `string`)
+
+## Examples of incorrect code for this rule:
+
+```js
+/* eslint saxo/string-constant-types: "error" */
+// @flow
+export const foo = 'foo'
+```
+
+## Examples of correct code for this rule:
+
+```js
+/* eslint saxo/string-constant-types: "error" */
+/* eslint-disable flowtype/require-valid-file-annotation */
+export const foo = 'foo'
+```
+
+```js
+/* eslint saxo/string-constant-types: "error" */
+// @flow
+export const foo: 'foo' = 'foo'
+```
+
+```js
+/* eslint saxo/string-constant-types: "error" */
+
+const foo = 'foo'
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-saxo",
-  "version": "1.3.0",
+  "version": "1.4.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13,6 +13,62 @@
         "@babel/highlight": "^7.0.0"
       }
     },
+    "@babel/generator": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
+      "integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.5.5",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.13",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+      "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.4.4"
+      }
+    },
     "@babel/highlight": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
@@ -22,6 +78,85 @@
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
+      "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
+      "dev": true
+    },
+    "@babel/template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+      "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.4.4",
+        "@babel/types": "^7.4.4"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
+      "integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.5.5",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.4.4",
+        "@babel/parser": "^7.5.5",
+        "@babel/types": "^7.5.5",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.13"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+          "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.0.0"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+      "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.13",
+        "to-fast-properties": "^2.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "abbrev": {
@@ -108,6 +243,32 @@
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
+    },
+    "babel-eslint": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.2.tgz",
+      "integrity": "sha512-UdsurWPtgiPgpJ06ryUnuaSXC2s0WoSZnQmEpbAH65XZSdwowgN5MvyP7e88nW07FYXv72erVtpBkxyDVKhH1Q==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "^1.0.0"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "3.7.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+          "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        }
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -908,6 +1069,12 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -1592,6 +1759,18 @@
       "requires": {
         "os-tmpdir": "~1.0.2"
       }
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
     },
     "tslib": {
       "version": "1.9.3",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "bugs": "https://github.com/saxobank/eslint-plugin-saxo/issues",
   "dependencies": {},
   "devDependencies": {
+    "babel-eslint": "^10.0.2",
     "eslint": "^5.16.0",
     "istanbul": "^0.4.4",
     "mocha": "^6.1.4"

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ module.exports = {
                 '@saxo/saxo/cy-viewport-presets': ['error', { allowed: ['phone', 'tablet', 'desktop'] }],
                 '@saxo/saxo/cy-viewport-literals': 'error',
                 '@saxo/saxo/no-cy-pause': 'error',
+                '@saxo/saxo/string-constant-types': 'error',
                 '@saxo/saxo/jsx-conditional-indent': 'error',
                 '@saxo/saxo/jsx-conditional-newline': 'error',
                 '@saxo/saxo/jsx-conditional-parens': 'error',

--- a/src/rules/string-constant-types.js
+++ b/src/rules/string-constant-types.js
@@ -1,0 +1,59 @@
+'use strict';
+
+module.exports = {
+    create(context) {
+        let isFlowAnnotated = false;
+
+        return {
+            Program(node) {
+                isFlowAnnotated = node.comments.some(
+                    (comment) => comment.value.trim() === '@flow'
+                );
+            },
+            ExportNamedDeclaration(node) {
+                if (!isFlowAnnotated) {
+                    return;
+                }
+
+                // E.g. export { default } from './container'
+                if (!node.declaration) {
+                    return;
+                }
+
+                if (node.declaration.kind !== 'const') {
+                    return;
+                }
+
+                const [declaration] = node.declaration.declarations;
+
+                if (!declaration.init || declaration.init.type !== 'Literal') {
+                    return;
+                }
+
+                if (typeof declaration.init.value !== 'string') {
+                    return;
+                }
+
+                if (declaration.id.typeAnnotation) {
+                    return;
+                }
+
+                const maxLiteralLength = 100;
+                if (declaration.init.value.length > maxLiteralLength) {
+                    return;
+                }
+
+                context.report({
+                    node: declaration,
+                    message: 'String literals should be typed',
+                    fix(fixer) {
+                        return fixer.insertTextAfter(
+                            declaration.id,
+                            `: ${declaration.init.raw}`
+                        );
+                    },
+                });
+            },
+        };
+    },
+};

--- a/src/rules/string-constant-types.js
+++ b/src/rules/string-constant-types.js
@@ -45,7 +45,7 @@ module.exports = {
 
                 context.report({
                     node: declaration,
-                    message: 'String literals should be typed',
+                    message: `String literals should be typed. Expected to be of the form \`${declaration.id}: ${declaration.init.raw}\``,
                     fix(fixer) {
                         return fixer.insertTextAfter(
                             declaration.id,

--- a/tests/lib/rules/string-constant-types.js
+++ b/tests/lib/rules/string-constant-types.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../../../src/rules/string-constant-types');
+
+const parserOptions = {
+    sourceType: 'module',
+    ecmaVersion: 6,
+};
+
+const stringLiteralsShouldBeTypedError = { message: 'String literals should be typed' };
+
+const ruleTester = new RuleTester({ parserOptions, parser: 'babel-eslint' });
+ruleTester.run('string-constant-types', rule, {
+    valid: [{
+        code:
+`
+// Doesn't complain when file isn't flow annotated
+export const constant = "value"
+`,
+    }, {
+        code:
+`
+// @flow
+// Doesn't complain when variable is already type annotated
+export const constant: 'foo' = 'foo'
+`,
+    }, {
+        code:
+`
+// @flow
+// Doesn't complain about other literal types not being explicitly typed
+export const numberLiteral = 5
+export const nullLiteral = null
+`,
+    }, {
+        code:
+`
+// @flow
+// Doesn't complain about string constants that aren't exported
+const nonExportedConstant = 'bar'
+`,
+    }],
+    invalid: [{
+        code:
+`
+// @flow
+export const foo = 'foo'
+`,
+        errors: [stringLiteralsShouldBeTypedError],
+    }],
+});

--- a/tests/lib/rules/string-constant-types.js
+++ b/tests/lib/rules/string-constant-types.js
@@ -14,28 +14,28 @@ const ruleTester = new RuleTester({ parserOptions, parser: 'babel-eslint' });
 ruleTester.run('string-constant-types', rule, {
     valid: [{
         code:
-`
+            `
 // Doesn't complain when file isn't flow annotated
 export const constant = "value"
 `,
     }, {
         code:
-`
+            `
 // @flow
 // Doesn't complain when variable is already type annotated
 export const constant: 'foo' = 'foo'
 `,
     }, {
         code:
-`
+            `
 // @flow
-// Doesn't complain about other literal types not being explicitly typed
+// Doesn't complain about non string literal types not being explicitly typed
 export const numberLiteral = 5
 export const nullLiteral = null
 `,
     }, {
         code:
-`
+            `
 // @flow
 // Doesn't complain about string constants that aren't exported
 const nonExportedConstant = 'bar'
@@ -43,7 +43,7 @@ const nonExportedConstant = 'bar'
     }],
     invalid: [{
         code:
-`
+            `
 // @flow
 export const foo = 'foo'
 `,


### PR DESCRIPTION
If any string in an enum is not typed then the enum is reverted to `string` (e.g. `'foo' | 'bar' | ... | string` -> `string`)

These can be introduced accidentally, and it isn't immediately obvious that types have become less strict.

This rule enforces that any exported string constant should be typed, to prevent the above from happening.