### PR TITLE
Add limit for featureTracking event length

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "tabWidth": 4,
+  "useTabs": false,
+  "singleQuote": true
+}

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ These rules are purely matters of style and are quite subjective.
 * [cy-viewport-max](docs/rules/cy-viewport-max.md): Enforces a limit on cypress viewport.
 * [cy-viewport-literals](docs/rules/cy-viewport-literals.md): Enforces the use of literals when setting cypress viewport.
 * [cy-viewport-presets](docs/rules/cy-viewport-presets.md): Enforces a specific set of cypress viewport presets.
+* [logevent-literal-max-len](docs/rules/logevent-literal-max-len.md): Ensures that logged event does not exceed 50 characters.
 
 # Contributing
 Contributions are always welcome!.

--- a/docs/rules/logevent-literal-max-len.md
+++ b/docs/rules/logevent-literal-max-len.md
@@ -1,0 +1,35 @@
+# logevent-literal-max-len
+
+This rule ensures logged event does not exceed 50 characters.
+
+## Rule Details
+
+Examples of incorrect code for this rule:
+
+```js
+/*eslint saxo/logevent-literal-max-len: "error"*/
+featureTracker.logEvent(
+    AREA,
+    'This string contains more characters than it should, which is 50 at the moment'
+);
+```
+
+```js
+/*eslint saxo/logevent-literal-max-len: "error"*/
+logEvent(
+    AREA,
+    'This string contains more characters than it should, which is 50 at the moment'
+);
+```
+
+Examples of correct code for this rule:
+
+```js
+/*eslint saxo/logevent-literal-max-len: "error"*/
+featureTracker.logEvent(AREA, 'Event occurred');
+```
+
+```js
+/*eslint saxo/logevent-literal-max-len: "error"*/
+logEvent(AREA, 'Event occurred', options);
+```

--- a/src/rules/logevent-literal-max-len.js
+++ b/src/rules/logevent-literal-max-len.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const FEATURE_EVENT_MAX_LENGTH = 50;
+
+module.exports = {
+    meta: {
+        docs: {
+            description: `ensure featureTracker event does not exceed ${FEATURE_EVENT_MAX_LENGTH} characters`,
+            recommended: false,
+        },
+        schema: [],
+        messages: {
+            logEventMaxLength: `featureEvent length should not exceed ${FEATURE_EVENT_MAX_LENGTH} characters`,
+        },
+    },
+    create(context) {
+        return {
+            CallExpression(node) {
+                const isFeatureTracker =
+                    node.callee.object &&
+                    node.callee.object.name === 'featureTracker' &&
+                    node.callee.property.name === 'logEvent';
+                const isLogEvent =
+                    node.callee.type === 'Identifier' &&
+                    node.callee.name === 'logEvent';
+                const secondArgument = node.arguments[1];
+
+                if (
+                    (isFeatureTracker || isLogEvent) &&
+                    secondArgument &&
+                    secondArgument.type === 'Literal' &&
+                    typeof secondArgument.value === 'string' &&
+                    secondArgument.value.length > FEATURE_EVENT_MAX_LENGTH
+                ) {
+                    context.report({
+                        node,
+                        messageId: 'logEventMaxLength',
+                    });
+                }
+            },
+        };
+    },
+};

--- a/tests/lib/rules/logevent-literal-max-len.js
+++ b/tests/lib/rules/logevent-literal-max-len.js
@@ -1,0 +1,63 @@
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const { RuleTester } = require('eslint');
+const rule = require('../../../src/rules/logevent-literal-max-len');
+const parserOptions = {
+    sourceType: 'module',
+    ecmaVersion: 6,
+    ecmaFeatures: {
+        jsx: true,
+    },
+};
+
+const logEventMaxLengthError = { messageId: 'logEventMaxLength' };
+const fiftyCharacters = '1234567890'.repeat(5);
+const sixtyCharacters = 'ABCD567890'.repeat(6);
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({ parserOptions });
+ruleTester.run('logevent-literal-max-len', rule, {
+    valid: [
+        {
+            code: `otherTracker.logEvent(AREA, "${sixtyCharacters}")`,
+        },
+        {
+            code: 'featureTracker.logEvent()',
+        },
+        {
+            code: 'featureTracker.logEvent(AREA, "Event occurred")',
+        },
+        {
+            code: `featureTracker.logEvent(AREA, ${sixtyCharacters})`,
+        },
+        {
+            code: `featureTracker.logEvent(AREA, "${fiftyCharacters}")`,
+        },
+        {
+            code: `featureTracker.logEvent(AREA, "${fiftyCharacters}", options)`,
+        },
+        {
+            code: `logEvent(AREA, "${fiftyCharacters}")`,
+        },
+        {
+            code: `logEvent(AREA, "${fiftyCharacters}", options)`,
+        },
+    ],
+    invalid: [
+        {
+            code: `featureTracker.logEvent(FEATURE_AREA, "${sixtyCharacters}")`,
+            errors: [logEventMaxLengthError],
+        },
+        {
+            code: `logEvent(FEATURE_AREA, "${sixtyCharacters}")`,
+            errors: [logEventMaxLengthError],
+        },
+    ],
+});


### PR DESCRIPTION
Problem: current definition of `event` column (TrackedEvents) allows 50 characters max.
This results in events not logged at all, when we exceed that limit on
the front-end.

This eslint plugin should give immediate feedback to developers about this limitation.
Until it's fixed on the DB side, we should keep that in mind.

Additionally, we should probably print the event in console as well.

Signed-off-by: Kuba Wolanin <hi@kubawolanin.com>